### PR TITLE
Update network browser logger, add mainnet URL check

### DIFF
--- a/network-browser/index.ts
+++ b/network-browser/index.ts
@@ -69,12 +69,12 @@ async function safeNetworkBrowserLoop() {
             await delay(NETWORK_BROWSER_DELAY)
         } catch (error) {
             if (error instanceof BrowserTimeoutError) {
-                console.error(
+                log.error(
                     `A timeout (${NETWORK_BROWSER_TIMEOUT} ms) error occurred:`,
                     error.message
                 )
             } else {
-                console.error('An error occurred in browse:', error)
+                log.error('An error occurred in browse:', error)
             }
             await delay(POST_ERROR_DELAY)
         }

--- a/network-browser/src/browser.ts
+++ b/network-browser/src/browser.ts
@@ -33,10 +33,10 @@ import {
     filterConnectedHashes
 } from './schains'
 import { getNodesGroups } from './nodes'
-import { CONNECTED_ONLY, IMA_NETWORK_BROWSER_DATA_PATH, LOG_LEVEL, LOG_PRETTY } from './constants'
-import { writeJson, currentTimestamp, chainIdInt } from './tools'
+import { CONNECTED_ONLY, IMA_NETWORK_BROWSER_DATA_PATH } from './constants'
+import { writeJson, currentTimestamp, chainIdInt, getLoggerConfig } from './tools'
 
-const log = new Logger<ILogObj>({ minLevel: LOG_LEVEL, stylePrettyLogs: LOG_PRETTY })
+const log = new Logger<ILogObj>(getLoggerConfig('browser'))
 
 export async function browse(schainsInternal: Contract, nodes: Contract): Promise<void> {
     log.info('Browse iteration started, collecting chains')

--- a/network-browser/src/constants.ts
+++ b/network-browser/src/constants.ts
@@ -56,3 +56,6 @@ export const NETWORK_BROWSER_TIMEOUT = secondsEnv(process.env.NETWORK_BROWSER_TI
 
 export const LOG_LEVEL = optionalEnvNumber('NETWORK_BROWSER_LOG_LEVEL', 1)
 export const LOG_PRETTY = booleanEnv('NETWORK_BROWSER_LOG_PRETTY', false)
+export const LOG_FORMAT =
+    '{{yyyy}}.{{mm}}.{{dd}} {{hh}}:{{MM}}:{{ss}}:{{ms}}\t{{logLevelName}}\t{{name}}\t'
+export const LOG_PREFIX = 'snb::'

--- a/network-browser/src/tools.ts
+++ b/network-browser/src/tools.ts
@@ -25,9 +25,24 @@ import { Logger, type ILogObj } from 'tslog'
 
 import { readFileSync, writeFileSync, renameSync } from 'fs'
 import { BrowserTimeoutError } from './errors'
-import { DEFAULT_PING_DELAY, DEFAULT_PING_ITERATIONS, LOG_LEVEL, LOG_PRETTY } from './constants'
+import {
+    DEFAULT_PING_DELAY,
+    DEFAULT_PING_ITERATIONS,
+    LOG_FORMAT,
+    LOG_LEVEL,
+    LOG_PRETTY
+} from './constants'
 
-const log = new Logger<ILogObj>({ minLevel: LOG_LEVEL, stylePrettyLogs: LOG_PRETTY })
+const log = new Logger<ILogObj>(getLoggerConfig('tools'))
+
+export function getLoggerConfig(moduleName: string): any {
+    return {
+        prettyLogTemplate: LOG_FORMAT,
+        minLevel: LOG_LEVEL,
+        stylePrettyLogs: LOG_PRETTY,
+        name: `snb::${moduleName}`
+    }
+}
 
 export function stringifyBigInt(obj: any): string {
     return JSON.stringify(


### PR DESCRIPTION
This PR adds 2 minor changes to the `network-browser` module:

- Updated log format to enhance readability
- Mainnet RPC URL check at startup

New log format example:

```
2024-01-30 13:18:13.685 INFO    snb::loop       Running network-browser...
2024-01-30 13:18:13.686 INFO    snb::loop       SCHAIN_NAME: xxxx
2024-01-30 13:18:13.686 INFO    snb::loop       POST_ERROR_DELAY: 5000
2024-01-30 13:18:13.686 INFO    snb::loop       MULTICALL: true
2024-01-30 13:18:13.686 INFO    snb::loop       CONNECTED_ONLY: true
2024-01-30 13:18:13.686 INFO    snb::loop       NETWORK_BROWSER_TIMEOUT: 1200000
2024-01-30 13:18:13.686 INFO    snb::loop       NETWORK_BROWSER_DELAY: 10800000
2024-01-30 13:18:13.686 INFO    snb::loop       Trying to connect to the sChain RPC: xxxx
2024-01-30 13:18:14.396 INFO    snb::tools      URL is available: xxxx
2024-01-30 13:18:14.396 INFO    snb::loop       Trying to connect to the mainnet RPC: xxxx
2024-01-30 13:18:14.594 INFO    snb::tools      URL is available: xxxx
2024-01-30 13:18:14.776 INFO    snb::browser    Browse iteration started, collecting chains
2024-01-30 13:18:15.906 INFO    snb::browser    Going to gather information about 5 chains
2024-01-30 13:18:16.463 INFO    snb::tools      Going to save data to file: ./test_schainsData.json
2024-01-30 13:18:16.465 INFO    snb::tools      Successfully moved the file from ./test_schainsData.json.tmp to ./test_schainsData.json
2024-01-30 13:18:16.465 INFO    snb::browser    Browse execution time: 1689.575959 ms (1.689575959 s) for 5 chains
```

No performance changes.
No additional tests needed.

Fixes https://github.com/skalenetwork/internal-support/issues/912