### PR TITLE
Ticket 910 hide sensitive data in agent log after start

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -129,9 +129,10 @@ function parseCommandLine(): void {
         log.add( imaState.strLogFilePath, imaState.nLogMaxSizeBeforeRotation,
             imaState.nLogMaxFilesCount );
     }
-    if( imaState.isPrintSecurityValues )
+    if( imaState.isPrintSecurityValues ) {
         log.information( "Agent was started with {} command line argument(s) as: {}",
-        process.argv.length, strPrintedArguments );
+            process.argv.length, strPrintedArguments );
+    }
     if( imaState.bIsNeededCommonInit ) {
         imaCLI.commonInit();
         imaCLI.initContracts();

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,7 +129,8 @@ function parseCommandLine(): void {
         log.add( imaState.strLogFilePath, imaState.nLogMaxSizeBeforeRotation,
             imaState.nLogMaxFilesCount );
     }
-    log.information( "Agent was started with {} command line argument(s) as: {}",
+    if( imaState.isPrintSecurityValues )
+        log.information( "Agent was started with {} command line argument(s) as: {}",
         process.argv.length, strPrintedArguments );
     if( imaState.bIsNeededCommonInit ) {
         imaCLI.commonInit();


### PR DESCRIPTION
Hidden sensitive data in agent log after start. Added reference to latest IMA sub-repo. No performance changes. No new tests needed.