### PR TITLE
Ticket 72 handle IMA 2 IMA net errors

### DIFF
--- a/runner/startup.js
+++ b/runner/startup.js
@@ -21,14 +21,18 @@ function terminateProcessGroup( processToKill ) {
     }
 }
 
-function onChildExit( otherChild, code, signal ) {
+function onChildExit( exitedChild, otherChild, code, signal ) {
+    console.log( "!!!IMA DOCKER CONTAINER WILL EXIT!!!" )
+    console.log( "Exited child:", exitedChild );
+    console.log( "Exit code:", code );
+    console.log( "Exit signal:", signal );
     terminateProcessGroup( otherChild );
     // Exit with the code or signal of the process that ended first
     process.exit( code || signal );
 }
 
-child1.on( "exit", ( code, signal ) => onChildExit( child2, code, signal ) );
-child2.on( "exit", ( code, signal ) => onChildExit( child1, code, signal ) );
+child1.on( "exit", function( code, signal ) { onChildExit( process.argv[2], child2, code, signal ); } );
+child2.on( "exit", function( code, signal ) { onChildExit( process.argv[3], child1, code, signal ); } );
 
 process.on( "SIGINT", () => {
     console.log( "Received SIGINT. Exiting..." );

--- a/src/log.ts
+++ b/src/log.ts
@@ -184,7 +184,6 @@ export function generateTimestampString( ts?: any, isColorized?: boolean ): stri
         ccBright( ":" ) + ccTime( n2s( ts.getUTCMinutes(), 2 ) ) +
         ccBright( ":" ) + ccTime( n2s( ts.getUTCSeconds(), 2 ) ) +
         ccBright( "." ) + ccFractionPartOfTime( n2s( ts.getUTCMilliseconds(), 3 ) );
-
     return s;
 }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -157,7 +157,7 @@ export function setPrintTimestamps( b?: boolean ): void {
 }
 
 export function n2s( n: any, sz: number ): string {
-    let s: string = n ?? "";
+    let s: string = n ? n.toString() : "";
     while( s.length < sz )
         s = "0" + s;
     return s;
@@ -168,6 +168,8 @@ export function generateTimestampString( ts?: any, isColorized?: boolean ): stri
         ( typeof isColorized === "undefined" )
             ? true
             : ( !!isColorized );
+    if( isColorized )
+        isColorized = cc.isEnabled();
     ts = ( ts instanceof Date ) ? ts : new Date();
     const ccDate = function( x?: any ): string { return isColorized ? cc.date( x ) : x; };
     const ccTime = function( x?: any ): string { return isColorized ? cc.time( x ) : x; };

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@
  * @copyright SKALE Labs 2019-Present
  */
 
-import express from "express";
+import express, { type Express, type NextFunction, type Request, type Response } from "express";
 import bodyParser from "body-parser";
 import * as ws from "ws";
 import * as owaspUtils from "./owaspUtils.js";
@@ -261,9 +261,11 @@ function initMonitoringServer(): void {
     } );
 }
 
-let gExpressJsonRpcAppIMA: any = null;
+let gExpressJsonRpcAppIMA: Express | null = null;
 
 function initJsonRpcServer(): void {
+    if( gExpressJsonRpcAppIMA )
+        return;
     const imaState: state.TIMAState = state.get();
     if( imaState.nJsonRpcPort <= 0 )
         return;
@@ -271,10 +273,29 @@ function initJsonRpcServer(): void {
     gExpressJsonRpcAppIMA = express();
     gExpressJsonRpcAppIMA.use( bodyParser.urlencoded( { extended: true } ) );
     gExpressJsonRpcAppIMA.use( bodyParser.json() );
-    gExpressJsonRpcAppIMA.post( "/", async function( req: any, res: any ): Promise<void> {
+    const errorHandler = function(
+        err: Error, req: Request, res: Response, next: NextFunction ): void {
+        if( err ) {
+            log.error(
+                "IMA-to-IMA network error, error is {err}, request is {}, response is {}",
+                err, req, res );
+            if( next )
+                next( err );
+        }
+    };
+    gExpressJsonRpcAppIMA.use( errorHandler );
+    const postHandler = async function( req: Request, res: Response ): Promise<void> {
         const isSkipMode = false;
         const message = JSON.stringify( req.body );
-        const ip = req.connection.remoteAddress.split( ":" ).pop();
+        const ip = req.socket.remoteAddress
+            ? req.socket.remoteAddress.split( ":" ).pop()
+            : "N/A-network-address";
+        req.on( "error", function() {
+            log.error( "IMA-to-IMA peer {} connection error, cannot process request", ip );
+        } );
+        res.on( "error", function() {
+            log.error( "IMA-to-IMA peer {} connection error, cannot send responses", ip );
+        } );
         const fnSendAnswer: any = function( joAnswer: any ): void {
             try {
                 res.header( "Content-Type", "application/json" );
@@ -325,10 +346,8 @@ function initJsonRpcServer(): void {
                     joMessage.params.nIndexS2S,
                     ( !!( joMessage.params.isStart ) ),
                     owaspUtils.toInteger( joMessage.params.ts ),
-                    joMessage.params.signature
-                ) )
+                    joMessage.params.signature ) )
                     await loop.spreadArrivedStateOfPendingWorkAnalysis( joMessage );
-
                 break;
             case "skale_getCachedSNB":
                 joAnswer.arrSChainsCached = skaleObserver.getLastCachedSChains();
@@ -347,6 +366,9 @@ function initJsonRpcServer(): void {
         }
         if( !isSkipMode )
             fnSendAnswer( joAnswer );
+    };
+    gExpressJsonRpcAppIMA.post( "/", function( req: Request, res: Response ): void {
+        postHandler( req, res ).then( function(): void {} ).catch( function(): void {} );
     } );
     gExpressJsonRpcAppIMA.listen( imaState.nJsonRpcPort );
 }


### PR DESCRIPTION
`IMA` uses express-based HTTP server to deliver IMA-2-IMA notifications like PWA state tracking. This PR fixes network connection problems by adding error handlers. Express-related code also ported from JS into TypeScript. No performance changes expected.
It's barely possible to cover all possible network problems with unit-tests, especially when connection problem appear after JSON request received and before answer is sent. Such errors can have guaranteed emulation only with modified source code of IMA Agent where network socket is manually damaged.
- - - - - - - - - - - - - - - - - - - - - - - - - -
New version's testing sequence and expected result on `dev net` is:
- disable Main Net connectivity on selected node
- restart IMA Agent
- wait `20-30` minutes
- expect normal shutdown of IMA Agent with exit code `163`
- expect no network errors and crashes in log output all this time 
- - - - - - - - - - - - - - - - - - - - - - - - - -
Old buggy version's notes:
- use same testing sequence
- expect crash of IMA Agent with network timeout error and no normal call stack 
- crash normally occur in less than 5 minutes
- crash does not change exit code to 163
