### PR TITLE
Update check url function in SNB

### DIFF
--- a/network-browser/index.ts
+++ b/network-browser/index.ts
@@ -26,7 +26,7 @@ import {
     getMainnetManagerAbi,
     getMainnetProvider
 } from './src/contracts'
-import { delay, getLoggerConfig, pingUrl, withTimeout } from './src/tools'
+import { delay, getLoggerConfig, checkEndpoint, withTimeout } from './src/tools'
 import { BrowserTimeoutError } from './src/errors'
 import { browse } from './src/browser'
 import {
@@ -54,9 +54,9 @@ async function safeNetworkBrowserLoop() {
     log.info(`NETWORK_BROWSER_DELAY: ${NETWORK_BROWSER_DELAY}`)
 
     log.info(`Trying to connect to the sChain RPC: ${SCHAIN_RPC_URL}`)
-    await pingUrl(SCHAIN_RPC_URL)
-    log.info(`Trying to connect to the mainnet RPC: ${MAINNET_RPC_URL}`)
-    await pingUrl(MAINNET_RPC_URL)
+    await checkEndpoint(SCHAIN_RPC_URL)
+    log.info(`Trying to connect to the mainnet RPC`)
+    await checkEndpoint(MAINNET_RPC_URL)
 
     const provider = await getMainnetProvider(MAINNET_RPC_URL, MULTICALL)
     const managerAbi = getMainnetManagerAbi()


### PR DESCRIPTION
This PR improves the check URL function in the SKALE network-browser to improve network provider compatibility.

In the previous version `fetch` with an empty body was used to check that mainnet and sChain endpoints were available, which failed for some providers (Infura for example). This PR fixes it using `provider.getBlockNumber` to determine if the endpoint is valid.

No additional tests are needed, and no performance changes.

Fixes https://github.com/skalenetwork/ima-agent/issues/85