### PR TITLE
Update github actions - use latest actions, fix docker compose

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cla:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "Get Team Members"
         id: team

--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -36,7 +36,7 @@ jobs:
         echo "============================================"
 
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@v1.3.1
       with:
         tool-cache: false  
         android: true

--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -24,11 +24,11 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
           submodules: recursive
 
-    - uses: oven-sh/setup-bun@v1
+    - uses: oven-sh/setup-bun@v2
 
     - name: INFO - github environment variable checks
       run: |
@@ -111,7 +111,7 @@ jobs:
         curl -fsSL https://get.docker.com -o install-docker.sh
         sudo sh install-docker.sh
         docker --version
-        docker-compose --version
+        docker compose --version
 
     - name: INIT - reconfigure docker and restart its daemon
       run: |
@@ -298,7 +298,7 @@ jobs:
         cd sgxwallet/run_sgx_sim
         rm -rf ../../local_sgxwallet_output_log.txt &> /dev/null
         echo " --------------------------- stopping sgx wallet ------------------------------------------------------------------------------------------------------ "
-        docker-compose down
+        docker compose down
         echo " --------------------------- fixing sgx wallets docker config ----------------------------------------------------------------------------------------- "
         mv docker-compose.yml docker-compose.yml.old-previous || true
         echo "version: '3'"                                 > docker-compose.yml
@@ -323,7 +323,7 @@ jobs:
         echo '        max-file: "4"'                       >> docker-compose.yml
         echo '    command: -s -y -V -d'                    >> docker-compose.yml
         echo " --------------------------- pulling sgx wallet ------------------------------------------------------------------------------------------------------- "
-        docker-compose pull
+        docker compose pull
         cd ../..
         cd ..
 
@@ -332,7 +332,7 @@ jobs:
       run: |
         cd comprehensive-test
         cd sgxwallet/run_sgx_sim
-        docker-compose up &> ../../local_sgxwallet_output_log.txt &
+        docker compose up &> ../../local_sgxwallet_output_log.txt &
         sleep 90
         cd ../..
         cd ..
@@ -409,7 +409,7 @@ jobs:
       run: |
         cd comprehensive-test
         cd sgxwallet/run_sgx_sim
-        docker-compose down
+        docker compose down
         cd ../..
         cd ..
 

--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -42,9 +42,9 @@ jobs:
         android: true
         dotnet: true
         haskell: true
-        large-packages: true
-        docker-images: true
-        swap-storage: true
+        large-packages: false
+        docker-images: false
+        swap-storage: false
 
     - name: DEBUG - Check disk space after cleanup
       run: |

--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   cancel-runs:
     name: Cancel Previous Runs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
@@ -20,7 +20,7 @@ jobs:
           access_token: ${{ github.token }}
   test-comprehensive:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
 

--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -24,6 +24,39 @@ jobs:
 
     steps:
 
+    - name: DEBUG - Check disk space before cleanup
+      run: |
+        echo "============================================"
+        echo "Disk space BEFORE cleanup:"
+        echo "============================================"
+        df -h
+        echo "============================================"
+        echo "Disk usage summary:"
+        df -h / | awk 'NR==2 {print "Total: "$2", Used: "$3", Available: "$4", Use%: "$5}'
+        echo "============================================"
+
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false  
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
+    - name: DEBUG - Check disk space after cleanup
+      run: |
+        echo "============================================"
+        echo "Disk space AFTER cleanup:"
+        echo "============================================"
+        df -h
+        echo "============================================"
+        echo "Disk usage summary:"
+        df -h / | awk 'NR==2 {print "Total: "$2", Used: "$3", Available: "$4", Use%: "$5}'
+        echo "============================================"
+
     - uses: actions/checkout@v5
       with:
           submodules: recursive

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
-  test-comprehensive:
+  test-comprehensive-container-test:
 
     runs-on: self-hosted
 

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   cancel-runs:
     name: Cancel Previous Runs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
 
-    - uses: oven-sh/setup-bun@v1
+    - uses: oven-sh/setup-bun@v2
 
     - name: INIT - force pre-clean
       run: |
@@ -41,11 +41,11 @@ jobs:
         sudo rm -rf ./sgxwallet || true
         sudo rm -rf ./transaction-manager || true
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
           submodules: recursive
     
-    - uses: oven-sh/setup-bun@v1
+    - uses: oven-sh/setup-bun@v2
 
     - name: INFO - github environment variable checks
       run: |
@@ -327,7 +327,7 @@ jobs:
         cd sgxwallet/run_sgx_sim
         rm -rf ../../local_sgxwallet_output_log.txt &> /dev/null
         echo " --------------------------- stopping sgx wallet ------------------------------------------------------------------------------------------------------ "
-        docker-compose down
+        docker compose down
         echo " --------------------------- fixing sgx wallets docker config ----------------------------------------------------------------------------------------- "
         mv docker-compose.yml docker-compose.yml.old-previous || true
         echo "version: '3'"                                 > docker-compose.yml
@@ -353,7 +353,7 @@ jobs:
         echo '        max-file: "4"'                       >> docker-compose.yml
         echo '    command: -s -y -V -d'                    >> docker-compose.yml
         echo " --------------------------- pulling sgx wallet ------------------------------------------------------------------------------------------------------- "
-        docker-compose pull
+        docker compose pull
         cd ../..
         cd ..
 
@@ -362,7 +362,7 @@ jobs:
       run: |
         cd comprehensive-test
         cd sgxwallet/run_sgx_sim
-        docker-compose up &> ../../local_sgxwallet_output_log.txt &
+        docker compose up &> ../../local_sgxwallet_output_log.txt &
         sleep 90
         cd ../..
         cd ..
@@ -457,7 +457,7 @@ jobs:
       run: |
         cd comprehensive-test
         cd sgxwallet/run_sgx_sim
-        docker-compose down
+        docker compose down
         cd ../..
         cd ..
 

--- a/.github/workflows/issue_check.yml
+++ b/.github/workflows/issue_check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check-linked-issues:
     name: Check if pull request has linked issues
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Get issues
         id: get-issues

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test-agent:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -167,7 +167,7 @@ jobs:
         # slither --version || true
 
   test-integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       working-directory: ./test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,11 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
           submodules: recursive
 
-    - uses: oven-sh/setup-bun@v1
+    - uses: oven-sh/setup-bun@v2
 
     - name: System Version Checks
       run: |
@@ -173,11 +173,11 @@ jobs:
       working-directory: ./test
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
           submodules: recursive
     
-    - uses: oven-sh/setup-bun@v1
+    - uses: oven-sh/setup-bun@v2
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,7 +183,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -191,7 +191,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/network-browser-test.yml
+++ b/.github/workflows/network-browser-test.yml
@@ -5,7 +5,7 @@ env:
   MANAGER_TAG: "1.9.3-beta.0"
 jobs:
   test_network_browser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/network-browser-test.yml
+++ b/.github/workflows/network-browser-test.yml
@@ -7,13 +7,13 @@ jobs:
   test_network_browser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           submodules: true
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
       - name: Launch hardhat node
         working-directory: hardhat-node
-        run: docker-compose up -d
+        run: docker compose up -d
       - name: Deploy manager contracts
         run: |
           bash ./helper-scripts/deploy_test_manager.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.merged == true
     env:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,11 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
         submodules: true
 
-    - uses: oven-sh/setup-bun@v1
+    - uses: oven-sh/setup-bun@v2
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path

--- a/network-browser/run_tests.sh
+++ b/network-browser/run_tests.sh
@@ -13,4 +13,4 @@ export SCHAIN_RPC_URL="http://127.0.0.1:8545"
 export SCHAIN_NAME="test"
 export CONNECTED_ONLY=false
 
-bun test
+bun test --timeout 80000

--- a/network-browser/run_tests.sh
+++ b/network-browser/run_tests.sh
@@ -13,4 +13,4 @@ export SCHAIN_RPC_URL="http://127.0.0.1:8545"
 export SCHAIN_NAME="test"
 export CONNECTED_ONLY=false
 
-bun test --timeout 80000
+bun test --timeout 90000


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use newer versions of key actions and standardizes Docker Compose commands. The main improvements are upgrading the `actions/checkout` and `oven-sh/setup-bun` actions to their latest major versions, and replacing deprecated `docker-compose` commands with the modern `docker compose` syntax throughout all workflow files.

**Action version upgrades:**

* Upgraded `actions/checkout` from `v2` to `v5` in `.github/workflows/comprehensive.yml`, `.github/workflows/container-test.yml`, `.github/workflows/main.yml`, `.github/workflows/network-browser-test.yml`, and `.github/workflows/publish.yml` [[1]](diffhunk://#diff-ed3ce592383bb6782a89c267ad6bd4970a1506da685d800b1b6ca16d394cabe7L27-R31) [[2]](diffhunk://#diff-087befbeeffccfe44172951ff59b735182c50dd82b492d4f1e14791ab7d5bf93L44-R48) [[3]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L22-R26) [[4]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L176-R180) [[5]](diffhunk://#diff-ca523381c376bddda4be242f623ffaf40f34a0c2fba8e93bcb5bf66f6de534d1L10-R16) [[6]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L23-R27).
* Upgraded `oven-sh/setup-bun` from `v1` to `v2` in all the above workflow files [[1]](diffhunk://#diff-ed3ce592383bb6782a89c267ad6bd4970a1506da685d800b1b6ca16d394cabe7L27-R31) [[2]](diffhunk://#diff-087befbeeffccfe44172951ff59b735182c50dd82b492d4f1e14791ab7d5bf93L27-R27) [[3]](diffhunk://#diff-087befbeeffccfe44172951ff59b735182c50dd82b492d4f1e14791ab7d5bf93L44-R48) [[4]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L22-R26) [[5]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L176-R180) [[6]](diffhunk://#diff-ca523381c376bddda4be242f623ffaf40f34a0c2fba8e93bcb5bf66f6de534d1L10-R16) [[7]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L23-R27).

**Docker Compose modernization:**

* Replaced all usages of the deprecated `docker-compose` CLI with the modern `docker compose` command in `.github/workflows/comprehensive.yml`, `.github/workflows/container-test.yml`, and `.github/workflows/network-browser-test.yml` [[1]](diffhunk://#diff-ed3ce592383bb6782a89c267ad6bd4970a1506da685d800b1b6ca16d394cabe7L114-R114) [[2]](diffhunk://#diff-ed3ce592383bb6782a89c267ad6bd4970a1506da685d800b1b6ca16d394cabe7L301-R301) [[3]](diffhunk://#diff-ed3ce592383bb6782a89c267ad6bd4970a1506da685d800b1b6ca16d394cabe7L326-R326) [[4]](diffhunk://#diff-ed3ce592383bb6782a89c267ad6bd4970a1506da685d800b1b6ca16d394cabe7L335-R335) [[5]](diffhunk://#diff-ed3ce592383bb6782a89c267ad6bd4970a1506da685d800b1b6ca16d394cabe7L412-R412) [[6]](diffhunk://#diff-087befbeeffccfe44172951ff59b735182c50dd82b492d4f1e14791ab7d5bf93L330-R330) [[7]](diffhunk://#diff-087befbeeffccfe44172951ff59b735182c50dd82b492d4f1e14791ab7d5bf93L356-R356) [[8]](diffhunk://#diff-087befbeeffccfe44172951ff59b735182c50dd82b492d4f1e14791ab7d5bf93L365-R365) [[9]](diffhunk://#diff-087befbeeffccfe44172951ff59b735182c50dd82b492d4f1e14791ab7d5bf93L460-R460) [[10]](diffhunk://#diff-ca523381c376bddda4be242f623ffaf40f34a0c2fba8e93bcb5bf66f6de534d1L10-R16).

These changes ensure compatibility with the latest GitHub Actions best practices and improve future maintainability.